### PR TITLE
meets会った日一覧を修正

### DIFF
--- a/app/controllers/meets_controller.rb
+++ b/app/controllers/meets_controller.rb
@@ -2,11 +2,10 @@ class MeetsController < ApplicationController
   before_action :set_user, only: %i[edit update destroy]
 
   def index
-    meet_arr = Meet.where(relationship_id: current_user.relationship_id).order(meet_day: :desc).limit(1).pluck(:meet_day)
-    @meet = meet_arr.first
+    @meet = Meet.where(relationship_id: current_user.relationship_id).order(meet_day: :desc).limit(1).pluck(:meet_day).first
 
-    @meets1 = Meet.where(relationship_id: current_user.relationship_id).order(meet_day: :desc).pluck(:meet_day)
-    @meets = @meets1 - @meet
+    meets_arr1 = Meet.where(relationship_id: current_user.relationship_id).order(meet_day: :desc).pluck(:meet_day)
+    @meets = meets_arr1.last(meets_arr1.length - 1)
   end
 
   def edit; end

--- a/app/views/meets/index.html.erb
+++ b/app/views/meets/index.html.erb
@@ -27,8 +27,10 @@
     </div>
     <div class="p-4 m-5">
       <div class="text-center">
-        <% @meets.each do |meets| %>
-          <ul><%= l meets %></ul>
+        <% if @meets %>
+          <% @meets.each do |meets| %>
+            <ul><%= l meets %></ul>
+          <% end %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
## 概要
issue番号 #52 

meetsモデルの会った日一覧を修正。
次会う日を抜いて表示できるようになった。
<img src="https://i.gyazo.com/479341de59d845b062e8de4aeb27bd27.png" width = "220px" height = "300px">

## コメント
編集機能をどうするかが今後の課題。
