### PR TITLE
user作成時にrelationshipも自動で作成されるよう修正

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -16,7 +16,9 @@ class DashboardsController < ApplicationController
     meet_arr = Meet.where(relationship_id: current_user.relationship_id).order(meet_day: :desc).limit(1)
     @meet = meet_arr.pluck(:meet_day).first
 
-    @day_count = (@meet - today).to_i
+    if @meet
+      @day_count = (@meet - today).to_i
+    end
 
     #effortsモデル
     my_effort_arr = Effort.where(user_id: current_user.id).pluck(:body)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,15 @@
 class UsersController < ApplicationController
   def new
+    @relationship = Relationship.new
     @user = User.new
   end
 
   def create
+    @relationship = Relationship.new
     @user = User.new(user_params)
-    if @user.save
+
+    if @user.save && @relationship.save
+      @user.update(relationship_id: @relationship.id)
       auto_login(@user)
       redirect_to dashboards_path, success: 'ユーザー登録が完了しました'
     else

--- a/app/views/meets/index.html.erb
+++ b/app/views/meets/index.html.erb
@@ -13,7 +13,13 @@
       <div class="text-center font-bold">次会う日は</div>
     </div>
     <div class="text-center text-gray-700 bg-white rounded-lg text-6xl p-4 m-5">
-      <div class="font-bold"><%= l @meet %></div>
+      <div class="font-bold">
+        <% if @meet %>
+          <%= l @meet %>
+        <% else %>
+          <%= まだ決まっていません %>
+        <% end %>
+      </div>
     </div>
     <div class="flex justify-center">
       <%# <%= link_to t('defaults.edit'), edit_meet_path(meet_attr.id), class: "bg-orange-400 hover:bg-orange-300 text-white font-bold py-2 px-4 border-b-4 border-orange-700 hover:border-orange-500 rounded-lg" %> %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -37,10 +37,10 @@
             </div>
             <div class="mb-3">
               <div class="form-check">
-                <input type="checkbox" class="form-check-input" id="agreeCheck">
-                <label class="form-check-label" for="agreeCheck"><span>I agree to the <a href="terms-condition-page.html">Terms of
-												Service </a>and
-											<a href="terms-condition-page.html">Privacy Policy.</a></span></label>
+                <%# <input type="checkbox" class="form-check-input" id="agreeCheck"> %>
+                <%# <label class="form-check-label" for="agreeCheck"><span>I agree to the <a href="terms-condition-page.html">Terms of %>
+												<%# Service </a>and %>
+											<%# <a href="terms-condition-page.html">Privacy Policy.</a></span></label> %>
               </div>
             </div>
             <div class="d-grid">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,66 +6,12 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
-# relationship
-
 puts "start"
 
-# 2.times do
-#   relationship = Relationship.create!
-#   puts "#{relationship.id}を作成しました"
-# end
-
-# # user
-# 2.times do
-#   user = User.create!(
-#       name: Faker::Name.name,
-#       email: Faker::Internet.email,
-#       password: 'password',
-#       password_confirmation: 'password',
-#       relationship_id: 1
-#   )
-#   puts "#{user.name}を作成しました"
-# end
-
-# # post
-# 2.times do |n|
-#   body = Faker::Creature::Dog.breed
-#   date = Faker::Date.in_date_period
-#   user = User.find(n + 1)
-#   post = Post.create!(body: body,
-#                       date: date,
-#                       user: user)
-#   puts "#{post.body}を作成しました"
-# end
-
-# # meet
-# 4.times do |n|
-#   meet = Meet.create!(
-#       meet_day: Faker::Date.between(from: 30.days.ago, to: Date.today),
-#       relationship_id: 1
-#   )
-#   puts "#{meet.meet_day}を作成しました"
-# end
-
-# Meet.create!(
-#   meet_day: "2023-03-22",
-#   relationship_id: 1
-# )
-
-# # reward
-# Reward.create!(
-#   not_meet_day: 30,
-#   content: "ディズニー！",
-#   relationship_id: 1
-# )
-
-# # efforts
-# Effort.create!(
-#   body: "筋トレ",
-#   user_id: 1
-# )
-
 # 花子
+relationship = Relationship.create!
+puts "#{relationship.id}を作成しました"
+
 user = User.create!(
   name: "花子",
   email: "example@example.com",
@@ -81,12 +27,17 @@ post = Post.create!(
   user_id: 1
 )
 
-4.times do |n|
+2.times do |n|
   meet = Meet.create!(
     meet_day: Faker::Date.between(from: 30.days.ago, to: Date.today),
     relationship_id: 1
   )
 end
+
+Meet.create!(
+  meet_day: "2023-03-22",
+  relationship_id: 1
+)
 
 Reward.create!(
   not_meet_day: 50,
@@ -97,6 +48,62 @@ Reward.create!(
 Effort.create!(
   body: "資格の勉強",
   user_id: 1
+)
+
+# relationship
+2.times do
+  relationship = Relationship.create!
+  puts "#{relationship.id}を作成しました"
+end
+
+# user
+2.times do
+  user = User.create!(
+      name: Faker::Name.name,
+      email: Faker::Internet.email,
+      password: 'password',
+      password_confirmation: 'password',
+      relationship_id: 2
+  )
+  puts "#{user.name}を作成しました"
+end
+
+# post
+2.times do |n|
+  body = Faker::Creature::Dog.breed
+  date = Faker::Date.in_date_period
+  user = User.find(n + 1)
+  post = Post.create!(body: body,
+                      date: date,
+                      user: user)
+  puts "#{post.body}を作成しました"
+end
+
+# meet
+4.times do |n|
+  meet = Meet.create!(
+      meet_day: Faker::Date.between(from: 30.days.ago, to: Date.today),
+      relationship_id: 2
+  )
+  puts "#{meet.meet_day}を作成しました"
+end
+
+Meet.create!(
+  meet_day: "2023-03-22",
+  relationship_id: 2
+)
+
+# reward
+Reward.create!(
+  not_meet_day: 30,
+  content: "ディズニー！",
+  relationship_id: 2
+)
+
+# efforts
+Effort.create!(
+  body: "筋トレ",
+  user_id: 2
 )
 
 puts "userは#{User.count}件"


### PR DESCRIPTION
## 概要
issue番号 #88 

user作成時にrelationshipも自動で作成されるよう修正した。
また、userのrelationship_idも自動で追加されるようにした。

## コメント
恋人登録機能はまだのため、恋人のuser作成時は別の方法で作成する。