### PR TITLE
デプロイできるようapplication.js修正

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,2 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
-import "controllers"


### PR DESCRIPTION
## 概要
turbo-rails, stimulus-rails gemを入れた影響で、デプロイが失敗したため、application.jsを修正。
