### PR TITLE
posts一覧からshowにとべるよう修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,6 +4,15 @@ class PostsController < ApplicationController
   def index
     @posts = Post.includes(:user).order(created_at: :desc).page(params[:page])
     @effort = Effort.find_by(user: current_user)
+
+    partner = User.where.not(id: current_user.id).where(relationship_id: current_user.relationship_id)
+    if partner == []
+      return
+    elsif partner
+      @partner = partner[0][:name]
+    end
+
+    @partner_effort = Effort.find_by(user: partner)
   end
 
   def show

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -5,7 +5,7 @@
       <%= render 'shared/error_messages', object: f.object %>
       <%= f.label :body %>
       <%= f.text_area :body ,class: "form-control mb-3", id: 'js-new-comment-body', rows: 4 %>
-      <%= f.submit t('defaults.post'), class: "btn" %>
+      <%= f.submit t('defaults.post'), class: "btn btn-accent" %>
     <% end %>
   </div>
 </div>

--- a/app/views/posts/_crud_menus.html.erb
+++ b/app/views/posts/_crud_menus.html.erb
@@ -1,12 +1,12 @@
-<ul class="flex ">
-  <li class="">
+<ul class="flex">
+  <li class="px-3">
     <%= link_to edit_post_path(post), id: "button-edit-#{post.id}" do %>
-      <%= icon('far', 'pen-to-square') %>
+      <%= icon('far', 'pen-to-square fa-1x') %>
     <% end %>
   </li>
-  <li class="">
+  <li class="px-3">
     <%= link_to post_path(post), data: { turbo_method: :delete, turbo_confirm: t('defaults.message.delete_confirm')} do %>
-      <%= icon('fa', 'trash') %>
+      <%= icon('fa', 'trash fa-1x') %>
     <% end %>
   </li>
 </ul>

--- a/app/views/posts/_crud_menus.html.erb
+++ b/app/views/posts/_crud_menus.html.erb
@@ -1,10 +1,10 @@
-<ul class="crud-menu-btn list-inline float-right">
-  <li class="list-inline-item">
+<ul class="flex ">
+  <li class="">
     <%= link_to edit_post_path(post), id: "button-edit-#{post.id}" do %>
       <%= icon('far', 'pen-to-square') %>
     <% end %>
   </li>
-  <li class="list-inline-item">
+  <li class="">
     <%= link_to post_path(post), data: { turbo_method: :delete, turbo_confirm: t('defaults.message.delete_confirm')} do %>
       <%= icon('fa', 'trash') %>
     <% end %>

--- a/app/views/posts/_effort.html.erb
+++ b/app/views/posts/_effort.html.erb
@@ -1,6 +1,15 @@
 <div class="flex justify-center bg-red-100">
-  <div class="m-7 text-2xl text-center">
-    <%= current_user.name %>ががんばること<br>
-    <%= effort.body %>
+  <div class="m-7 text-center">
+    <div class="text-2xl"><%= current_user.name %>ががんばること</div>
+    <div class="text-4xl font-bold"><%= effort.body %></div>
   </div>
 </div>
+<br>
+<% if @partner %>
+  <div class="flex justify-center bg-red-100">
+  <div class="m-7 text-center">
+      <div class="text-2xl"><%= @partner %>ががんばること</div>
+      <div class="text-4xl font-bold"><%= @partner_effort.body %></div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,18 +1,24 @@
 <div class="col-sm-12 col-lg-4 mb-3 bg-white rounded-lg p-4 m-5">
   <div id="post-id-<%= post.id %>">
     <div class="container mx-auto flex justify-between items-center">
-      <div></div>
-      <div class="text-center">
+      <div class="px-10 mx-20">
+        <td style="width: 60px">
+          <%= image_tag post.user.avatar_url, class: 'rounded-circle', size: '70x70' %>
+        </td>
+      </div>
+      <div class="text-1xl">
         <%= l post.date, format: :long %>
       </div>
-      <div class="float-right">
+      <div class="">
         <% if current_user.own?(post) %>
           <%= render 'crud_menus', post: post %>
         <% end %>
       </div>
     </div>
     <div class="text-center font-bold text-2xl">
-      <%= post.body %>
+      <%= link_to post_path(post) do %>
+        <%= post.body %>
+      <% end %>
     </div>
     <div class="flex justify-center">
       <% if post.image? %>  <!-- アップロード画像がある場合に実行する -->

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,18 +1,23 @@
 <div class="col-sm-12 col-lg-4 mb-3 bg-white rounded-lg p-4 m-5">
   <div id="post-id-<%= post.id %>">
-    <div class="card">
-      <div class="card-body">
-        <h4 class="card-title">
-          <%= l post.date, format: :long %>
-        </h4>
+    <div class="container mx-auto flex justify-between items-center">
+      <div></div>
+      <div class="text-center">
+        <%= l post.date, format: :long %>
+      </div>
+      <div class="float-right">
         <% if current_user.own?(post) %>
           <%= render 'crud_menus', post: post %>
         <% end %>
-        <p class="card-text"><%= post.body %></p>
-        <% if post.image? %>  <!-- アップロード画像がある場合に実行する -->
-          <%= image_tag post.image.url, class: 'card-img-top', size: '300x200' %><!-- boardインスタンスの画像ファイルのURLを取得し表示 -->
-        <% end %>
       </div>
+    </div>
+    <div class="text-center font-bold text-2xl">
+      <%= post.body %>
+    </div>
+    <div class="flex justify-center">
+      <% if post.image? %>  <!-- アップロード画像がある場合に実行する -->
+        <%= image_tag post.image.url, class: 'card-img-top', size: '300x200' %><!-- boardインスタンスの画像ファイルのURLを取得し表示 -->
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,14 +1,14 @@
 <%= content_for(:title, t('.title')) %>
 <div class="text-center text-gray-700">
-  <div class="p-4 m-5">
+  <div class="p-3 m-2">
     <div class="text-4xl">
       <div class="font-bold"><%= t('.title') %></div>
     </div>
   </div>
 </div>
 <%# 「がんばりを伝える」ボタン %>
-<div class="flex justify-center p-4 m-5">
-  <div class="text-1xl font-bold">
+<div class="flex justify-center p-1 m-2">
+  <div class="text-2xl font-bold">
     <%= link_to t('posts.new.title'), new_post_path, class: 'btn btn-accent' %>
   </div>
 </div>
@@ -19,7 +19,7 @@
   <% end %>
 </div>
 
-  <!-- 掲示板一覧 -->
+  <!-- がんばり記録一覧 -->
 <div class="justify-center">
   <div class="col-12">
     <div class="row">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -10,14 +10,28 @@
 <article class="bg-white rounded-lg p-4 m-5">
   <div class="card-body">
     <div class='row'>
-      <div class='col-md-9'>
-        <div class="text-left">by <%= @post.user.name %></div>
-        <% if current_user.own?(@post) %>
-          <%= render 'crud_menus', post: @post %>
-        <% end %>
-        <div class="text-center"><%= @post.date %></div>
-        <div class="text-center"><%= @post.body %></div>
-        <div class='col-md-3'>
+      <div class="text-left">by <%= @post.user.name %></div>
+        <div class='col-md-9'><div class="container mx-auto flex justify-between items-center">
+          <div class="px-10 mx-20">
+            <td style="width: 60px">
+              <%= image_tag @post.user.avatar_url, class: 'rounded-circle', size: '70x70' %>
+            </td>
+          </div>
+          <div class="text-1xl">
+            <%= l @post.date, format: :long %>
+          </div>
+          <div class="">
+            <% if current_user.own?(@post) %>
+              <%= render 'crud_menus', post: @post %>
+            <% end %>
+          </div>
+        </div>
+        <div class="text-center font-bold text-2xl">
+          <%= link_to post_path(@post) do %>
+            <%= @post.body %>
+          <% end %>
+        </div>
+        <div class='col-md-3 flex justify-center'>
           <% if @post.image? %>  <!-- アップロード画像がある場合に実行する -->
             <%= image_tag @post.image.url, class: 'card-img-top img-fluid', size: '300x200' %>
           <% end %>


### PR DESCRIPTION
## 概要
issue番号 #99 

posts一覧からshowにとべるよう修正した。
ついでにposts関連のCSSも最低限で修正した。

## コメント
各postのタイトルとcrud_menusとアイコンの間がうまくCSSで調整できず、よく見ると非常に気持ち悪い。