### PR TITLE
本番環境のパスワードリセット機能実装

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,9 +62,18 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "enmusubi_production"
 
-  config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = Settings.default_url_options.to_h
-
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  host = 'enkyori-enmusubi.com'
+  config.action_mailer.default_url_options = { protocol: 'https', host: host }
+  ActionMailer::Base.smtp_settings = {
+    :port           => ENV['MAILGUN_SMTP_PORT'],
+    :address        => ENV['MAILGUN_SMTP_SERVER'],
+    :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
+    :password       => ENV['MAILGUN_SMTP_PASSWORD'],
+    :domain         => host,
+    :authentication => :plain,
+  }
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
## 概要
issue番号 #172 

herokuのアドオンmailgunを使用して、本番環境のパスワードリセット実装。
smtp設定追加。
https://railstutorial.jp/chapters/password_reset?version=5.1

## コメント
gmailを使いたくなったら、また追加で修正する。